### PR TITLE
Adding curl as a dependency

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -155,7 +155,7 @@ check_command() {
 
 echo "Checking dependencies..."
 DEPS_TO_INSTALL=""
-COMMON_DEPS="p7zip wget wrestool icotool convert npx"
+COMMON_DEPS="curl file p7zip wget wrestool icotool convert npx"
 DEB_DEPS="dpkg-deb"
 APPIMAGE_DEPS="" 
 ALL_DEPS_TO_CHECK="$COMMON_DEPS"
@@ -169,6 +169,8 @@ for cmd in $ALL_DEPS_TO_CHECK; do
     if ! check_command "$cmd"; then
         case "$cmd" in
             "p7zip") DEPS_TO_INSTALL="$DEPS_TO_INSTALL p7zip-full" ;;
+            "curl") DEPS_TO_INSTALL="$DEPS_TO_INSTALL curl" ;;
+            "file") DEPS_TO_INSTALL="$DEPS_TO_INSTALL file" ;;
             "wget") DEPS_TO_INSTALL="$DEPS_TO_INSTALL wget" ;;
             "wrestool"|"icotool") DEPS_TO_INSTALL="$DEPS_TO_INSTALL icoutils" ;;
             "convert") DEPS_TO_INSTALL="$DEPS_TO_INSTALL imagemagick" ;;


### PR DESCRIPTION
```
197.9 ./build.sh: line 270: curl: command not found                                                                                                                           
197.9 ❌ Failed to download Claude Desktop installer from https://storage.googleapis.com/osprey-downloads-c02f6a0d-347c-492b-a752-3e0651722e97/nest-win-x64/Claude-Setup-x64.e
xe 
```

So I just added curl as a dependency.